### PR TITLE
Use tabs to switch between chat, notes, and reminders

### DIFF
--- a/public/drp-37/src/App.module.css
+++ b/public/drp-37/src/App.module.css
@@ -1,6 +1,7 @@
 .App {
   text-align: center;
   font-family: Verdana, Arial, sans-serif;
+  margin-top: 10vh;
 }
 
 .button {

--- a/public/drp-37/src/App.tsx
+++ b/public/drp-37/src/App.tsx
@@ -3,12 +3,13 @@ import { reminderHandlerGenerator } from "./reminders/Reminders";
 
 import styles from "./App.module.css";
 import { A } from "@solidjs/router";
+import { otherName } from "./messages/Message";
 
 const TWO_MINUTES_MILLI = 120000;
 const TWO_HOURS_MILLI = 7.2e6;
 const TWO_DAYS_MILLI = 1.728e8;
 
-const App: Component = () => {
+const App: Component<{ name: string }> = (props) => {
   // const [data, { refetch }] = createResource(getRemindMes);
 
   const [remindDate, setRemindDate] = createSignal(new Date().toString());
@@ -48,7 +49,7 @@ const App: Component = () => {
     <div class={styles.App}>
       <div>
         <h3>You can set reminders here! Set a message and a date :)</h3>
-        <p>Remind me to text Carl</p>
+        <p>Remind me to text {otherName(props.name)}</p>
         <textarea
           ref={textRef!}
           style={{ height: "5vh", width: "60vw" }}
@@ -88,7 +89,6 @@ const App: Component = () => {
         </button>
       </div>
       <br />
-      <A href="/">To Index</A>
     </div>
   );
 };

--- a/public/drp-37/src/messages/Message.tsx
+++ b/public/drp-37/src/messages/Message.tsx
@@ -11,6 +11,8 @@ import { A } from "@solidjs/router";
 
 import style from "./message.module.css";
 
+import App from "../App";
+
 export type MessageRecord = {
   from: string;
   content: string;
@@ -161,7 +163,17 @@ export const otherName = (name: string) => {
   return name === "Carl" ? "Alex" : "Carl";
 };
 
+const NotesPage: Component = () => {
+  return (
+    <div>
+      <h3 class={style.notes_header}> Notes</h3>
+      <input type="text" class={style.notes_input}></input>
+    </div>
+  );
+};
+
 const MessagePage: Component<{ name: string }> = (props) => {
+  var [shownPage, setShownPage] = createSignal(0);
   return (
     <div
       classList={{
@@ -171,15 +183,41 @@ const MessagePage: Component<{ name: string }> = (props) => {
       <div class={style.navbar}>
         <div class={style.message_header}>
           <A href={"/" + props.name}>
-            <button> Back </button>
+            <button class={style.header_button}> Back </button>
           </A>
-          <p class={style.chatWith}>Chat with: {otherName(props.name)}</p>
-          <A href="/app">
-            <button> Reminders </button>
-          </A>
+          <button
+            class={style.header_button}
+            onclick={() => {
+              setShownPage(0);
+            }}
+          >
+            {" "}
+            Chat{" "}
+          </button>
+          <p class={style.chatWith}>{otherName(props.name)}</p>
+          <button
+            class={style.header_button}
+            onclick={() => {
+              setShownPage(1);
+            }}
+          >
+            {" "}
+            Notes{" "}
+          </button>
+          <button
+            class={style.header_button}
+            onClick={() => {
+              setShownPage(2);
+            }}
+          >
+            {" "}
+            Reminders{" "}
+          </button>
         </div>
       </div>
-      <MessagePlatform name={props.name} />
+      {shownPage() == 0 && <MessagePlatform name={props.name} />}
+      {shownPage() == 1 && <NotesPage />}
+      {shownPage() == 2 && <App name={props.name} />}
     </div>
   );
 };

--- a/public/drp-37/src/messages/message.module.css
+++ b/public/drp-37/src/messages/message.module.css
@@ -34,13 +34,18 @@
 .message_header {
   margin-left: auto;
   margin-right: auto;
-  width: 70%;
+  width: 98%;
 
   align-items: center;
 
   display: grid;
-  grid-template-columns: 8vw auto 8vw;
+  grid-template-columns: 15vw 15vw auto 15vw 20vw;
   text-align: center;
+}
+
+.header_button {
+  margin-left: 1vw;
+  margin-right: 1vw;
 }
 
 .navbar {
@@ -177,4 +182,17 @@
 
 .chatWith {
   font-size: 1rem;
+}
+
+.notes_header {
+  margin-top: 10vh;
+  text-align: center;
+}
+
+.notes_input {
+  width: 80vw;
+  margin-left: 10vw;
+  margin-right: 10vw;
+  margin-top: 5vh;
+  height: 50vh;
 }

--- a/public/drp-37/src/navigation/PersonHome.tsx
+++ b/public/drp-37/src/navigation/PersonHome.tsx
@@ -31,9 +31,6 @@ const PersonPage: Component<{ name: string }> = (props) => {
             <button> Back </button>
           </A>
           <p class={style.chatWith}>{props.name}'s homepage</p>
-          <A href="/app">
-            <button> Reminders </button>
-          </A>
         </div>
       </div>
 


### PR DESCRIPTION
Using signals, has a value on the front end for which page to display Reminders nw only accessible from the chat page
Reminders now uses props to allow for context around people